### PR TITLE
 Removed background image 

### DIFF
--- a/src/app/static/app/css/style.css
+++ b/src/app/static/app/css/style.css
@@ -136,7 +136,7 @@
 /**************************************************************************************************************************************/
 /*  GLOBAL */
 
-    html, body { background: #222b32 url('../img/bg.png') top center no-repeat; }
+    /* html, body { background: #222b32 url('../img/bg.png') top center no-repeat; } */
     #main { max-width: 1280px; margin: 0 auto; background: #fff; position: relative; overflow-x: hidden; }
         .banner_error { position: absolute; top: 80px; left: 30px; color: #ff0000; }
     .container { max-width: 980px; margin: 0 auto; /* this controls the width of the site for media queries - check at the bottom of this file */ }

--- a/src/app/static/app/css/stylehomepage.css
+++ b/src/app/static/app/css/stylehomepage.css
@@ -139,7 +139,7 @@
 /**************************************************************************************************************************************/
 /*  HEADER */
 
-    #header { max-width: 100%; height: 74px; background: #fff url('../img/border.png') bottom repeat-x; position: relative; z-index: 1000; }
+    #header { max-width: 100%; height: 74px; background: #fff; position: relative; z-index: 1000; }
         #header .logo { width: 162px; height: 41px; float: left; margin: 16px 0 0 30px; background: url('../img/logo.png') no-repeat; }
         /*#header .mobi_handle { display: none; }*/
         #header ul { float: right; margin: 0; padding: 0; list-style: none; }


### PR DESCRIPTION
Removed the body background image under Globals in style.css that shows up on the StartUps and Events pages as people scroll down the page. Whenever people scroll on the JoziHub website there is a black block that shows up and then disappears. The block comes from the background image that is applied site wide.